### PR TITLE
[ENTESB-11765] spring-boot-camel-xml pulls wrong FMP version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
                     <plugin>
                         <groupId>org.jboss.redhat-fuse</groupId>
                         <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${fuse.bom.version}</version>
                         <configuration>
                             <enricher>
                                 <excludes>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-11765

Added missing version for fabric8-maven-plugin.